### PR TITLE
Adds serial number scanning capabilities

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,5 +50,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.android.gms:play-services-auth:20.7.0")
 
+    implementation("com.google.android.gms:play-services-code-scanner:16.1.0")
+
     compileOnly(files("${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"))
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.InventoryPro"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".Activities.AddItemActivity"
@@ -26,6 +27,10 @@
         <activity
             android:name=".Activities.MainActivity"
             android:exported="false" />
+        <meta-data
+            android:name="com.google.mlkit.vision.DEPENDENCIES"
+            android:value="barcode" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/inventorypro/Activities/AddItemActivity.java
+++ b/app/src/main/java/com/example/inventorypro/Activities/AddItemActivity.java
@@ -15,6 +15,7 @@ import com.example.inventorypro.Helpers;
 import com.example.inventorypro.Item;
 import com.example.inventorypro.R;
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -34,7 +35,7 @@ public class AddItemActivity extends AppCompatActivity {
     private TextInputLayout description;
     private TextInputLayout comments;
     private TextInputLayout value;
-    private ImageButton addTagButton, addImageButton, addCodeButton;
+    private ImageButton addTagButton, addImageButton, serialNumberScanButton;
     private int selectedPosition;
     private boolean editMode = false;
     List<String> tags;
@@ -65,11 +66,28 @@ public class AddItemActivity extends AppCompatActivity {
 
         addTagButton = findViewById(R.id.addTagButton);
         addImageButton = findViewById(R.id.addImageButton);
-        addCodeButton = findViewById(R.id.addcode_button);
+        serialNumberScanButton = findViewById(R.id.serialNumberScanButton);
 
         addTagButton.setOnClickListener(Helpers.notImplementedClickListener);
         addImageButton.setOnClickListener(Helpers.notImplementedClickListener);
-        addCodeButton.setOnClickListener(Helpers.notImplementedClickListener);
+
+        serialNumberScanButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                GmsBarcodeScanning.getClient(getBaseContext())
+                    .startScan()
+                    .addOnSuccessListener(barcode -> {
+                        serialNumber.getEditText().setText(barcode.getRawValue());
+                    })
+                    .addOnCanceledListener(() -> {
+                        Helpers.toast(getBaseContext(), getString(R.string.barcode_scan_cancelled_message));
+                    })
+                    .addOnFailureListener(e -> {
+                        String failureMessage = getString(R.string.barcode_scan_failed_message) + e.getMessage();
+                        Helpers.toast(getBaseContext(), failureMessage);
+                    });
+            }
+        });
 
         //calls sendItem if all inputs are valid
         confirmButton.setOnClickListener(new View.OnClickListener() {
@@ -94,7 +112,9 @@ public class AddItemActivity extends AppCompatActivity {
         });
 
         // Try to get a new item from the intent.
-        Item potentialItem = parseItemFromAddItemActivity();
+        Item potentialItem = tryGetItemFromIntent();
+        String potentialSerialNumber = tryGetSerialNumberFromIntent();
+
         if (potentialItem != null) {
             // Set EditText values to the values of the selected Item
             name.getEditText().setText(potentialItem.getName());
@@ -110,6 +130,8 @@ public class AddItemActivity extends AppCompatActivity {
             // Change the header to "Edit Item"
             header.setText("Edit Item");
             editMode = true;
+        } else if (potentialSerialNumber != null) {
+            serialNumber.getEditText().setText(potentialSerialNumber);
         }
     }
 
@@ -233,15 +255,20 @@ public class AddItemActivity extends AppCompatActivity {
      *
      * @return New Item if created; otherwise, returns null.
      */
-    private Item parseItemFromAddItemActivity() {
+    private Item tryGetItemFromIntent() {
         Intent receiverIntent = getIntent();
-        Item receivedItem = receiverIntent.getParcelableExtra("edit");
-        selectedPosition = getIntent().getIntExtra("editPositon", -1);
+        Item receivedItem = receiverIntent.getParcelableExtra(getString(R.string.edit_item_intent));
+        selectedPosition = getIntent().getIntExtra(getString(R.string.edit_item_position_intent), -1);
 
         if (receivedItem == null) {
             return null;
         }
 
         return receivedItem;
+    }
+
+    private String tryGetSerialNumberFromIntent() {
+        Intent receiverIntent = getIntent();
+        return receiverIntent.getStringExtra(getString(R.string.serial_number_intent));
     }
 }

--- a/app/src/main/java/com/example/inventorypro/Fragments/ViewItemFragment.java
+++ b/app/src/main/java/com/example/inventorypro/Fragments/ViewItemFragment.java
@@ -135,8 +135,8 @@ public class ViewItemFragment extends DialogFragment {
     private void editItem(){
         Intent sendItemIntent = new Intent(getContext(), AddItemActivity.class);
         //sends the item back to main activity
-        sendItemIntent.putExtra("edit", selectedItem);
-        sendItemIntent.putExtra("editPositon", selectedPosition);
+        sendItemIntent.putExtra(getString(R.string.edit_item_intent), selectedItem);
+        sendItemIntent.putExtra(getString(R.string.edit_item_position_intent), selectedPosition);
         startActivity(sendItemIntent);
     }
     public ViewItemFragment() {

--- a/app/src/main/java/com/example/inventorypro/ItemList.java
+++ b/app/src/main/java/com/example/inventorypro/ItemList.java
@@ -259,6 +259,22 @@ public class ItemList {
         return itemList.get(position);
     }
 
+
+    /**
+     * Gets position of the first item for a given serial number
+     * @param serialNumber The serial number of interest.
+     * @return position of item if such an item exists, otherwise -1
+     */
+    public int getPositionFromSerialNumber(String serialNumber) {
+        for (int i = 0; i < itemList.size(); i++) {
+            if (serialNumber.equals(itemList.get(i).getSerialNumber())) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
     /**
      * Gets the total value of all items in the list.
      * @return the total value of all items in the list.

--- a/app/src/main/res/layout/activity_add_item.xml
+++ b/app/src/main/res/layout/activity_add_item.xml
@@ -240,7 +240,7 @@
                     android:textColor="@color/purple" />
             </com.google.android.material.textfield.TextInputLayout>
             <ImageButton
-                android:id="@+id/addcode_button"
+                android:id="@+id/serialNumberScanButton"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:background="@color/white"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,9 @@
     <string name="logout_token">logout</string>
     <string name="sort_bar_heading">Sort:</string>
     <string name="filter_bar_heading">Filters:</string>
+    <string name="barcode_scan_cancelled_message">Barcode scanning was cancelled</string>
+    <string name="barcode_scan_failed_message">Barcode scanning was failed due to: </string>
+    <string name="serial_number_intent">serialnumber</string>
+    <string name="edit_item_intent">edit</string>
+    <string name="edit_item_position_intent">editPosition</string>
 </resources>


### PR DESCRIPTION
Serial number scanning is relevant only in the following two cases.

Case 1: In MainActivity (ItemList)
When serial number is scanned in the main screen, the app first checks if there is an existing item with the scanned serial number.
If such an item exists, the edit item screen is opened for that item. If such an item doesn't exist, the edit item screen is opened with only the serial number filled in.

Case 2: Inside Edit Item view
When serial number is scanned from within the edit item screen, the serial number is set to the barcode value